### PR TITLE
Update references to release branches

### DIFF
--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__debug-artifacts.yml
+++ b/.github/workflows/__debug-artifacts.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__go-custom-tracing-autobuild.yml
+++ b/.github/workflows/__go-custom-tracing-autobuild.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__go-custom-tracing.yml
+++ b/.github/workflows/__go-custom-tracing.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__ml-powered-queries.yml
+++ b/.github/workflows/__ml-powered-queries.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__test-ruby.yml
+++ b/.github/workflows/__test-ruby.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL action"
 
 on:
   push:
-    branches: [main, v1, v2]
+    branches: [main, releases/v1, releases/v2]
   pull_request:
-    branches: [main, v1, v2]
+    branches: [main, releases/v1, releases/v2]
     # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
     # by other workflows.
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -15,8 +15,8 @@ on:
 
   push:
     branches:
-      - v1
-      - v2
+      - releases/v1
+      - releases/v2
 
 jobs:
   merge-back:
@@ -101,7 +101,7 @@ jobs:
           git push origin --force --follow-tags "${VERSION}"
 
       - name: Create mergeback branch
-        if: steps.check.outputs.exists != 'true' && contains(github.ref, 'v2')
+        if: steps.check.outputs.exists != 'true' && contains(github.ref, 'releases/v2')
         env:
           VERSION: "${{ steps.getVersion.outputs.version }}"
           NEW_BRANCH: "${{ steps.getVersion.outputs.newBranch }}"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,7 @@ name: PR Checks (Basic Checks and Runner)
 
 on:
   push:
-    branches: [main, v1, v2]
+    branches: [main, releases/v1, releases/v2]
   pull_request:
     # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
     # by other workflows.

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -2,7 +2,7 @@ name: Test Python Package Installation on Linux and Mac
 
 on:
   push:
-    branches: [main, v1, v2]
+    branches: [main, releases/v1, releases/v2]
   pull_request:
     # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
     # by other workflows.

--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -7,7 +7,7 @@ on:
   # When the v2 release is complete, this workflow will open a PR to update the v1 release branch.
   push:
     branches:
-      - v2
+      - releases/v2
 
 jobs:
   update:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,22 +61,22 @@ Here are a few things you can do that will increase the likelihood of your pull 
 ## Releasing (write access required)
 
 1. The first step of releasing a new version of the `codeql-action` is running the "Update release branch" workflow.
-    This workflow goes through the pull requests that have been merged to `main` since the last release, creates a changelog, then opens a pull request to merge the changes since the last release into the `v2` release branch.
+    This workflow goes through the pull requests that have been merged to `main` since the last release, creates a changelog, then opens a pull request to merge the changes since the last release into the `releases/v2` release branch.
 
     You can start a release by triggering this workflow via [workflow dispatch](https://github.com/github/codeql-action/actions/workflows/update-release-branch.yml).
-1. The workflow run will open a pull request titled "Merge main into v2". Mark the pull request as [ready for review](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review) to trigger the PR checks.
+1. The workflow run will open a pull request titled "Merge main into releases/v2". Mark the pull request as [ready for review](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review) to trigger the PR checks.
 1. Review the checklist items in the pull request description.
     Once you've checked off all but the last two of these, approve the PR and automerge it.
-1. When the "Merge main into v2" pull request is merged into the `v2` branch, the "Tag release and merge back" workflow will create a mergeback PR.
-    This mergeback incorporates the changelog updates into `main`, tags the release using the merge commit of the "Merge main into v2" pull request, and bumps the patch version of the CodeQL Action.
+1. When the "Merge main into releases/v2" pull request is merged into the `releases/v2` branch, the "Tag release and merge back" workflow will create a mergeback PR.
+    This mergeback incorporates the changelog updates into `main`, tags the release using the merge commit of the "Merge main into releases/v2" pull request, and bumps the patch version of the CodeQL Action.
 
     Approve the mergeback PR and automerge it.
-1. When the "Merge main into v2" pull request is merged into the `v2` branch, the "Update release branch" workflow will create a "Merge v2 into v1" pull request to merge the changes since the last release into the `v1` release branch.
-    This ensures we keep both the `v1` and `v2` release branches up to date and fully supported.
+1. When the "Merge main into releases/v2" pull request is merged into the `releases/v2` branch, the "Update release branch" workflow will create a "Merge releases/v2 into releases/v1" pull request to merge the changes since the last release into the `releases/v1` release branch.
+    This ensures we keep both the `releases/v1` and `releases/v2` release branches up to date and fully supported.
 
     Review the checklist items in the pull request description.
     Once you've checked off all the items, approve the PR and automerge it.
-1. Once the mergeback has been merged to `main` and the "Merge v2 into v1" PR has been merged to `v1`, the release is complete.
+1. Once the mergeback has been merged to `main` and the "Merge releases/v2 into releases/v1" PR has been merged to `releases/v1`, the release is complete.
 
 ## Keeping the PR checks up to date (admin access required)
 
@@ -91,8 +91,8 @@ To regenerate the PR jobs for the action:
     CHECKS="$(gh api repos/github/codeql-action/commits/${SHA}/check-runs --paginate | jq --slurp --compact-output --raw-output '[.[].check_runs | .[].name | select(contains("https://") or . == "CodeQL" or . == "LGTM.com" or . == "Update dependencies" or . == "Update Supported Enterprise Server Versions" | not)]')"
     echo "{\"contexts\": ${CHECKS}}" > checks.json
     gh api -X "PATCH" repos/github/codeql-action/branches/main/protection/required_status_checks --input checks.json
-    gh api -X "PATCH" repos/github/codeql-action/branches/v2/protection/required_status_checks --input checks.json
-    gh api -X "PATCH" repos/github/codeql-action/branches/v1/protection/required_status_checks --input checks.json
+    gh api -X "PATCH" repos/github/codeql-action/branches/releases/v2/protection/required_status_checks --input checks.json
+    gh api -X "PATCH" repos/github/codeql-action/branches/releases/v1/protection/required_status_checks --input checks.json
     ````
 
 2. Go to the [branch protection rules settings page](https://github.com/github/codeql-action/settings/branches) and validate that the rules have been updated.

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -108,7 +108,7 @@ for file in os.listdir('checks'):
             },
             'on': {
                 'push': {
-                    'branches': ['main', 'v1', 'v2']
+                    'branches': ['main', 'releases/v1', 'releases/v2']
                 },
                 'pull_request': {
                     'types': ["opened", "synchronize", "reopened", "ready_for_review"]


### PR DESCRIPTION
Prepare for renaming `v1` -> `releases/v1` and `v2` -> `releases/v2`.

### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
