### PR TITLE
Migrate to using tags to reference releases rather than branches

### DIFF
--- a/.github/workflows/__analyze-ref-input.yml
+++ b/.github/workflows/__analyze-ref-input.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__debug-artifacts.yml
+++ b/.github/workflows/__debug-artifacts.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__extractor-ram-threads.yml
+++ b/.github/workflows/__extractor-ram-threads.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__go-custom-queries.yml
+++ b/.github/workflows/__go-custom-queries.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__go-custom-tracing-autobuild.yml
+++ b/.github/workflows/__go-custom-tracing-autobuild.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__go-custom-tracing.yml
+++ b/.github/workflows/__go-custom-tracing.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__javascript-source-root.yml
+++ b/.github/workflows/__javascript-source-root.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__ml-powered-queries.yml
+++ b/.github/workflows/__ml-powered-queries.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__multi-language-autodetect.yml
+++ b/.github/workflows/__multi-language-autodetect.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__packaging-config-inputs-js.yml
+++ b/.github/workflows/__packaging-config-inputs-js.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__packaging-config-js.yml
+++ b/.github/workflows/__packaging-config-js.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__packaging-inputs-js.yml
+++ b/.github/workflows/__packaging-inputs-js.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__remote-config.yml
+++ b/.github/workflows/__remote-config.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__rubocop-multi-language.yml
+++ b/.github/workflows/__rubocop-multi-language.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__split-workflow.yml
+++ b/.github/workflows/__split-workflow.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__test-local-codeql.yml
+++ b/.github/workflows/__test-local-codeql.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__test-proxy.yml
+++ b/.github/workflows/__test-proxy.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__test-ruby.yml
+++ b/.github/workflows/__test-ruby.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__unset-environment.yml
+++ b/.github/workflows/__unset-environment.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__upload-ref-sha-input.yml
+++ b/.github/workflows/__upload-ref-sha-input.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/__with-checkout-path.yml
+++ b/.github/workflows/__with-checkout-path.yml
@@ -11,8 +11,8 @@ on:
   push:
     branches:
     - main
-    - v1
-    - v2
+    - releases/v1
+    - releases/v2
   pull_request:
     types:
     - opened

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,9 +2,9 @@ name: "CodeQL action"
 
 on:
   push:
-    branches: [main, v1, v2]
+    branches: [main, releases/v1, releases/v2]
   pull_request:
-    branches: [main, v1, v2]
+    branches: [main, releases/v1, releases/v2]
     # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
     # by other workflows.
     types: [opened, synchronize, reopened, ready_for_review]

--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -21,7 +21,6 @@ on:
 jobs:
   merge-back:
     runs-on: ubuntu-latest
-    if: github.repository == 'github/codeql-action'
     env:
       BASE_BRANCH: "${{ github.event.inputs.baseBranch || 'main' }}"
       HEAD_BRANCH: "${{ github.head_ref || github.ref }}"

--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Dump GitHub context
         env:
           GITHUB_CONTEXT: '${{ toJson(github) }}'
-        run: echo "$GITHUB_CONTEXT"
+        run: echo "${GITHUB_CONTEXT}"
 
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -47,25 +47,25 @@ jobs:
         id: getVersion
         run: |
           VERSION="v$(jq '.version' -r 'package.json')"
-          SHORT_SHA="${GITHUB_SHA:0:8}"
-          echo "::set-output name=version::$VERSION"
-          NEW_BRANCH="mergeback/${VERSION}-to-${BASE_BRANCH}-${SHORT_SHA}"
-          echo "::set-output name=newBranch::$NEW_BRANCH"
+          echo "::set-output name=version::${VERSION}"
+          short_sha="${GITHUB_SHA:0:8}"
+          NEW_BRANCH="mergeback/${VERSION}-to-${BASE_BRANCH}-${short_sha}"
+          echo "::set-output name=newBranch::${NEW_BRANCH}"
 
 
       - name: Dump branches
         env:
           NEW_BRANCH: "${{ steps.getVersion.outputs.newBranch }}"
         run: |
-          echo "BASE_BRANCH $BASE_BRANCH"
-          echo "HEAD_BRANCH $HEAD_BRANCH"
-          echo "NEW_BRANCH $NEW_BRANCH"
+          echo "BASE_BRANCH ${BASE_BRANCH}"
+          echo "HEAD_BRANCH ${HEAD_BRANCH}"
+          echo "NEW_BRANCH ${NEW_BRANCH}"
 
       - name: Create mergeback branch
         env:
           NEW_BRANCH: "${{ steps.getVersion.outputs.newBranch }}"
         run: |
-          git checkout -b "$NEW_BRANCH"
+          git checkout -b "${NEW_BRANCH}"
 
       - name: Check for tag
         id: check
@@ -73,13 +73,13 @@ jobs:
           VERSION: "${{ steps.getVersion.outputs.version }}"
         run: |
           set +e # don't fail on an errored command
-          git ls-remote --tags origin | grep "$VERSION"
-          EXISTS="$?"
-          if [ "$EXISTS" -eq 0 ]; then
-            echo "Tag $TAG exists. Not going to re-release."
+          git ls-remote --tags origin | grep "${VERSION}"
+          exists="$?"
+          if [ "${exists}" -eq 0 ]; then
+            echo "Tag ${VERSION} exists. Not going to re-release."
             echo "::set-output name=exists::true"
           else
-            echo "Tag $TAG does not exist yet."
+            echo "Tag ${VERSION} does not exist yet."
           fi
 
       # we didn't tag the release during the update-release-branch workflow because the
@@ -108,8 +108,8 @@ jobs:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         run: |
           set -exu
-          PR_TITLE="Mergeback $VERSION $HEAD_BRANCH into $BASE_BRANCH"
-          PR_BODY="Updates version and changelog."
+          pr_title="Mergeback ${VERSION} ${HEAD_BRANCH} into ${BASE_BRANCH}"
+          pr_body="Updates version and changelog."
 
           # Update the version number ready for the next release
           npm version patch --no-git-tag-version
@@ -117,16 +117,16 @@ jobs:
           # Update the changelog
           perl -i -pe 's/^/## \[UNRELEASED\]\n\nNo user facing changes.\n\n/ if($.==3)' CHANGELOG.md
           git add .
-          git commit -m "Update changelog and version after $VERSION"
+          git commit -m "Update changelog and version after ${VERSION}"
 
-          git push origin "$NEW_BRANCH"
+          git push origin "${NEW_BRANCH}"
 
           # PR checks won't be triggered on PRs created by Actions. Therefore mark the PR as draft
           # so that a maintainer can take the PR out of draft, thereby triggering the PR checks.
           gh pr create \
-            --head "$NEW_BRANCH" \
-            --base "$BASE_BRANCH" \
-            --title "$PR_TITLE" \
+            --head "${NEW_BRANCH}" \
+            --base "${BASE_BRANCH}" \
+            --title "${pr_title}" \
             --label "Update dependencies" \
-            --body "$PR_BODY" \
+            --body "${pr_body}" \
             --draft

--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -1,7 +1,8 @@
 # This workflow runs after a release of the action. For v2 releases, it merges any changes from the
 # release back into the main branch. Typically, this is just a single commit that updates the
-# changelog. For v2 and v1 releases, it then tags the merge commit on the release branch that
-# represents the new release.
+# changelog. For v2 and v1 releases, it then (a) tags the merge commit on the release branch that
+# represents the new release with an `vx.y.z` tag and (b) updates the `vx` tag to refer to this
+# commit.
 name: Tag release and merge back
 
 on:
@@ -89,9 +90,15 @@ jobs:
         env:
           VERSION: ${{ steps.getVersion.outputs.version }}
         run: |
-          git tag -a "$VERSION" -m "$VERSION"
-          git fetch --unshallow  # unshallow the repo in order to allow pushes
-          git push origin --follow-tags "$VERSION"
+          # Unshallow the repo in order to allow pushes
+          git fetch --unshallow
+          # Create the `vx.y.z` tag
+          git tag -a "${VERSION}" -m "${VERSION}"
+          # Update the `vx` tag
+          major_version_tag=$(cut -d '.' -f1 <<< "${VERSION}")
+          git tag -a "${major_version_tag}" -m "${major_version_tag}"
+          # Push the tags, using `--force` since we're overwriting the `vx` tag
+          git push origin --force --follow-tags "${VERSION}" "${major_version_tag}"
 
       - name: Create mergeback branch
         if: steps.check.outputs.exists != 'true' && contains(github.ref, 'v2')

--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -1,7 +1,7 @@
-# This workflow runs after a release of the action.
-# It merges any changes from the release back into the
-# main branch. Typically, this is just a single commit
-# that updates the changelog.
+# This workflow runs after a release of the action. For v2 releases, it merges any changes from the
+# release back into the main branch. Typically, this is just a single commit that updates the
+# changelog. For v2 and v1 releases, it then tags the merge commit on the release branch that
+# represents the new release.
 name: Tag release and merge back
 
 on:

--- a/.github/workflows/post-release-mergeback.yml
+++ b/.github/workflows/post-release-mergeback.yml
@@ -15,8 +15,8 @@ on:
 
   push:
     branches:
-      - v1
-      - v2
+      - releases/v1
+      - releases/v2
 
 jobs:
   merge-back:
@@ -101,7 +101,7 @@ jobs:
           git push origin --force --follow-tags "${VERSION}" "${major_version_tag}"
 
       - name: Create mergeback branch
-        if: steps.check.outputs.exists != 'true' && contains(github.ref, 'v2')
+        if: steps.check.outputs.exists != 'true' && contains(github.ref, 'releases/v2')
         env:
           VERSION: "${{ steps.getVersion.outputs.version }}"
           NEW_BRANCH: "${{ steps.getVersion.outputs.newBranch }}"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,7 +2,7 @@ name: PR Checks (Basic Checks and Runner)
 
 on:
   push:
-    branches: [main, v1, v2]
+    branches: [main, releases/v1, releases/v2]
   pull_request:
     # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
     # by other workflows.

--- a/.github/workflows/python-deps.yml
+++ b/.github/workflows/python-deps.yml
@@ -2,7 +2,7 @@ name: Test Python Package Installation on Linux and Mac
 
 on:
   push:
-    branches: [main, v1, v2]
+    branches: [main, releases/v1, releases/v2]
   pull_request:
     # Run checks on reopened draft PRs to support triggering PR checks on draft PRs that were opened
     # by other workflows.

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -8,7 +8,7 @@ jobs:
     name: Update dependencies
     timeout-minutes: 45
     runs-on: macos-latest
-    if: contains(github.event.pull_request.labels.*.name, 'Update dependencies') && (github.event.pull_request.head.repo.full_name == 'github/codeql-action')
+    if: contains(github.event.pull_request.labels.*.name, 'Update dependencies')
     steps:
     - name: Checkout repository
       uses: actions/checkout@v3

--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -7,7 +7,7 @@ on:
   # When the v2 release is complete, this workflow will open a PR to update the v1 release branch.
   push:
     branches:
-      - v2
+      - releases/v2
 
 jobs:
   update:

--- a/.github/workflows/update-release-branch.yml
+++ b/.github/workflows/update-release-branch.yml
@@ -13,7 +13,6 @@ jobs:
   update:
     timeout-minutes: 45
     runs-on: ubuntu-latest
-    if: github.repository == 'github/codeql-action'
     steps:
     - name: Dump environment
       run: env

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,22 +61,22 @@ Here are a few things you can do that will increase the likelihood of your pull 
 ## Releasing (write access required)
 
 1. The first step of releasing a new version of the `codeql-action` is running the "Update release branch" workflow.
-    This workflow goes through the pull requests that have been merged to `main` since the last release, creates a changelog, then opens a pull request to merge the changes since the last release into the `v2` release branch.
+    This workflow goes through the pull requests that have been merged to `main` since the last release, creates a changelog, then opens a pull request to merge the changes since the last release into the `releases/v2` release branch.
 
     You can start a release by triggering this workflow via [workflow dispatch](https://github.com/github/codeql-action/actions/workflows/update-release-branch.yml).
-1. The workflow run will open a pull request titled "Merge main into v2". Mark the pull request as [ready for review](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review) to trigger the PR checks.
+1. The workflow run will open a pull request titled "Merge main into releases/v2". Mark the pull request as [ready for review](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/changing-the-stage-of-a-pull-request#marking-a-pull-request-as-ready-for-review) to trigger the PR checks.
 1. Review the checklist items in the pull request description.
     Once you've checked off all but the last two of these, approve the PR and automerge it.
-1. When the "Merge main into v2" pull request is merged into the `v2` branch, the "Tag release and merge back" workflow will create a mergeback PR.
-    This mergeback incorporates the changelog updates into `main`, tags the release using the merge commit of the "Merge main into v2" pull request, and bumps the patch version of the CodeQL Action.
+1. When the "Merge main into releases/v2" pull request is merged into the `releases/v2` branch, the "Tag release and merge back" workflow will create a mergeback PR.
+    This mergeback incorporates the changelog updates into `main`, tags the release using the merge commit of the "Merge main into releases/v2" pull request, and bumps the patch version of the CodeQL Action.
 
     Approve the mergeback PR and automerge it.
-1. When the "Merge main into v2" pull request is merged into the `v2` branch, the "Update release branch" workflow will create a "Merge v2 into v1" pull request to merge the changes since the last release into the `v1` release branch.
-    This ensures we keep both the `v1` and `v2` release branches up to date and fully supported.
+1. When the "Merge main into releases/v2" pull request is merged into the `releases/v2` branch, the "Update release branch" workflow will create a "Merge releases/v2 into releases/v1" pull request to merge the changes since the last release into the `releases/v1` release branch.
+    This ensures we keep both the `releases/v1` and `releases/v2` release branches up to date and fully supported.
 
     Review the checklist items in the pull request description.
     Once you've checked off all the items, approve the PR and automerge it.
-1. Once the mergeback has been merged to `main` and the "Merge v2 into v1" PR has been merged to `v1`, the release is complete.
+1. Once the mergeback has been merged to `main` and the "Merge releases/v2 into releases/v1" PR has been merged to `releases/v1`, the release is complete.
 
 ## Keeping the PR checks up to date (admin access required)
 
@@ -91,8 +91,8 @@ To regenerate the PR jobs for the action:
     CHECKS="$(gh api repos/github/codeql-action/commits/${SHA}/check-runs --paginate | jq --slurp --compact-output --raw-output '[.[].check_runs | .[].name | select(contains("https://") or . == "CodeQL" or . == "LGTM.com" or . == "Update dependencies" or . == "Update Supported Enterprise Server Versions" | not)]')"
     echo "{\"contexts\": ${CHECKS}}" > checks.json
     gh api -X "PATCH" repos/github/codeql-action/branches/main/protection/required_status_checks --input checks.json
-    gh api -X "PATCH" repos/github/codeql-action/branches/v2/protection/required_status_checks --input checks.json
-    gh api -X "PATCH" repos/github/codeql-action/branches/v1/protection/required_status_checks --input checks.json
+    gh api -X "PATCH" repos/github/codeql-action/branches/releases/v2/protection/required_status_checks --input checks.json
+    gh api -X "PATCH" repos/github/codeql-action/branches/releases/v1/protection/required_status_checks --input checks.json
     ````
 
 2. Go to the [branch protection rules settings page](https://github.com/github/codeql-action/settings/branches) and validate that the rules have been updated.

--- a/pr-checks/sync.py
+++ b/pr-checks/sync.py
@@ -108,7 +108,7 @@ for file in os.listdir('checks'):
             },
             'on': {
                 'push': {
-                    'branches': ['main', 'v1', 'v2']
+                    'branches': ['main', 'releases/v1', 'releases/v2']
                 },
                 'pull_request': {
                     'types': ["opened", "synchronize", "reopened", "ready_for_review"]


### PR DESCRIPTION
### Merge / deployment checklist

- [ ] Confirm this change is backwards compatible with existing workflows.
- [ ] Confirm the [readme](https://github.com/github/codeql-action/blob/main/README.md) has been updated if necessary.
- [ ] Confirm the [changelog](https://github.com/github/codeql-action/blob/main/CHANGELOG.md) has been updated if necessary.
